### PR TITLE
fix #1528 django-constance: can't disable boolean setting

### DIFF
--- a/src/unfold/contrib/constance/settings.py
+++ b/src/unfold/contrib/constance/settings.py
@@ -15,6 +15,7 @@ UNFOLD_CONSTANCE_ADDITIONAL_FIELDS = {
         "django.forms.BooleanField",
         {
             "widget": "unfold.widgets.UnfoldBooleanSwitchWidget",
+            "required": False,
         },
     ],
     "file_field": [


### PR DESCRIPTION
The issue occurs because Django Unfold's constance integration uses django.forms.BooleanField with the default
  configuration, which has required=True by default. In Django's BooleanField:
  - required=True means the checkbox MUST be checked for the form to validate
  - required=False means the checkbox can be either checked (True) or unchecked (False/None)

  When a user tries to uncheck a boolean setting in django-constance through Unfold's interface, the form validation
   fails because the BooleanField expects the checkbox to be checked (since required=True).